### PR TITLE
Force getFile to use highest quality videos

### DIFF
--- a/ios/Classes/SwiftPhotoGalleryPlugin.swift
+++ b/ios/Classes/SwiftPhotoGalleryPlugin.swift
@@ -346,6 +346,7 @@ public class SwiftPhotoGalleryPlugin: NSObject, FlutterPlugin {
         || asset.mediaType == PHAssetMediaType.audio) {
         let options = PHVideoRequestOptions()
         options.isNetworkAccessAllowed = true
+        options.deliveryMode = .highQualityFormat
         options.version = .current
         
         manager.requestAVAsset(forVideo: asset, options: options, resultHandler: { (avAsset, avAudioMix, info) in


### PR DESCRIPTION
It looks like images are forced to be in high quality (see line 321) but videos aren't. This commit forces videos to be in high quality format