### PR TITLE
Fix: use sub path /Document/photo_gallery to save file

### DIFF
--- a/ios/Classes/SwiftPhotoGalleryPlugin.swift
+++ b/ios/Classes/SwiftPhotoGalleryPlugin.swift
@@ -409,7 +409,7 @@ public class SwiftPhotoGalleryPlugin: NSObject, FlutterPlugin {
     let tempFolder = paths[0].appendingPathComponent("photo_gallery")
     try! FileManager.default.createDirectory(at: tempFolder, withIntermediateDirectories: true, attributes: nil)
     
-    return paths[0].appendingPathComponent(mediumId+ext)
+    return tempFolder.appendingPathComponent(mediumId+ext)
   }
   
   private func toSwiftMediumType(value: String) -> PHAssetMediaType? {


### PR DESCRIPTION
Thanks a lot for the library, it's very clear and useful.

I was trying to add some feature to filter assets, then found and fix an issue: the "tempFolder" created intentionally to save the file is not used. 

Btw, it's better to use '.cachesDirectory' to create the temp folder.
`let paths = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)`

From Jianjun