### PR TITLE
Fixed null album name

### DIFF
--- a/lib/src/models/album.dart
+++ b/lib/src/models/album.dart
@@ -22,7 +22,7 @@ class Album {
   Album.fromJson(dynamic json)
       : id = json['id'],
         mediumType = jsonToMediumType(json['mediumType']),
-        name = json['name'],
+        name = json['name']==null?"":json['name'],
         count = json['count'];
 
   /// list media in the album.


### PR DESCRIPTION
I made a solution to prevent exception when the album name is null, as described in #30.

With this fix, applications won't stop loading the albums' list when some photos are present in `/sdcard` on Android devices.