### PR TITLE
Adding the orientation parameter of images and videos for Android

### DIFF
--- a/android/src/main/kotlin/com/morbit/photogallery/PhotoGalleryPlugin.kt
+++ b/android/src/main/kotlin/com/morbit/photogallery/PhotoGalleryPlugin.kt
@@ -58,6 +58,7 @@ class PhotoGalleryPlugin : FlutterPlugin, MethodCallHandler {
             MediaStore.Images.Media._ID,
             MediaStore.Images.Media.WIDTH,
             MediaStore.Images.Media.HEIGHT,
+            MediaStore.Images.Media.ORIENTATION,
             MediaStore.Images.Media.MIME_TYPE,
             MediaStore.Images.Media.DATE_TAKEN,
             MediaStore.Images.Media.DATE_MODIFIED
@@ -67,6 +68,7 @@ class PhotoGalleryPlugin : FlutterPlugin, MethodCallHandler {
             MediaStore.Video.Media._ID,
             MediaStore.Video.Media.WIDTH,
             MediaStore.Video.Media.HEIGHT,
+            MediaStore.Images.Media.ORIENTATION,
             MediaStore.Video.Media.MIME_TYPE,
             MediaStore.Video.Media.DURATION,
             MediaStore.Video.Media.DATE_TAKEN,
@@ -790,6 +792,7 @@ class PhotoGalleryPlugin : FlutterPlugin, MethodCallHandler {
         val idColumn = cursor.getColumnIndex(MediaStore.Images.Media._ID)
         val widthColumn = cursor.getColumnIndex(MediaStore.Images.Media.WIDTH)
         val heightColumn = cursor.getColumnIndex(MediaStore.Images.Media.HEIGHT)
+        val orientationColumn = cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
         val mimeColumn = cursor.getColumnIndex(MediaStore.Images.Media.MIME_TYPE)
         val dateTakenColumn = cursor.getColumnIndex(MediaStore.Images.Media.DATE_TAKEN)
         val dateModifiedColumn = cursor.getColumnIndex(MediaStore.Images.Media.DATE_MODIFIED)
@@ -797,6 +800,7 @@ class PhotoGalleryPlugin : FlutterPlugin, MethodCallHandler {
         val id = cursor.getLong(idColumn)
         val width = cursor.getLong(widthColumn)
         val height = cursor.getLong(heightColumn)
+        val orientation = cursor.getLong(orientationColumn)
         val mimeType = cursor.getString(mimeColumn)
         var dateTaken: Long? = null
         if (cursor.getType(dateTakenColumn) == FIELD_TYPE_INTEGER) {
@@ -812,6 +816,7 @@ class PhotoGalleryPlugin : FlutterPlugin, MethodCallHandler {
             "mediumType" to imageType,
             "width" to width,
             "height" to height,
+            "orientation" to orientation,
             "mimeType" to mimeType,
             "creationDate" to dateTaken,
             "modifiedDate" to dateModified
@@ -822,6 +827,7 @@ class PhotoGalleryPlugin : FlutterPlugin, MethodCallHandler {
         val idColumn = cursor.getColumnIndex(MediaStore.Video.Media._ID)
         val widthColumn = cursor.getColumnIndex(MediaStore.Video.Media.WIDTH)
         val heightColumn = cursor.getColumnIndex(MediaStore.Video.Media.HEIGHT)
+        val orientationColumn = cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
         val mimeColumn = cursor.getColumnIndex(MediaStore.Video.Media.MIME_TYPE)
         val durationColumn = cursor.getColumnIndex(MediaStore.Video.Media.DURATION)
         val dateTakenColumn = cursor.getColumnIndex(MediaStore.Video.Media.DATE_TAKEN)
@@ -830,6 +836,7 @@ class PhotoGalleryPlugin : FlutterPlugin, MethodCallHandler {
         val id = cursor.getLong(idColumn)
         val width = cursor.getLong(widthColumn)
         val height = cursor.getLong(heightColumn)
+        val orientation = cursor.getLong(orientationColumn)
         val mimeType = cursor.getString(mimeColumn)
         val duration = cursor.getLong(durationColumn)
         var dateTaken: Long? = null
@@ -845,6 +852,7 @@ class PhotoGalleryPlugin : FlutterPlugin, MethodCallHandler {
             "id" to id.toString(),
             "mediumType" to videoType,
             "width" to width,
+            "orientation" to orientation,
             "height" to height,
             "mimeType" to mimeType,
             "duration" to duration,

--- a/lib/src/models/medium.dart
+++ b/lib/src/models/medium.dart
@@ -17,6 +17,9 @@ class Medium {
   /// The medium height.
   final int? height;
 
+  /// The medium orientation.
+  final int? orientation;
+
   /// The medium mimeType.
   final String? mimeType;
 
@@ -34,6 +37,7 @@ class Medium {
     this.mediumType,
     this.width,
     this.height,
+    this.orientation = 0,
     this.mimeType,
     this.duration = 0,
     this.creationDate,
@@ -46,6 +50,7 @@ class Medium {
         mediumType = jsonToMediumType(json["mediumType"]),
         width = json["width"],
         height = json["height"],
+        orientation = json["orientation"],
         mimeType = json["mimeType"],
         duration = json['duration'] ?? 0,
         creationDate = json['creationDate'] != null
@@ -61,6 +66,7 @@ class Medium {
       mediumType: jsonToMediumType(map['mediumType']),
       width: map['width'],
       height: map['height'],
+      orientation: map['orientation'],
       mimeType: map["mimeType"],
       creationDate: map['creationDate'],
       modifiedDate: map['modifiedDate'],
@@ -72,6 +78,7 @@ class Medium {
       "id": this.id,
       "mediumType": mediumTypeToJson(this.mediumType),
       "height": this.height,
+      "orientation": this.orientation,
       "mimeType": this.mimeType,
       "width": this.width,
       "creationDate": this.creationDate,
@@ -111,6 +118,7 @@ class Medium {
           mediumType == other.mediumType &&
           width == other.width &&
           height == other.height &&
+          orientation == other.orientation &&
           mimeType == other.mimeType &&
           creationDate == other.creationDate &&
           modifiedDate == other.modifiedDate;
@@ -121,6 +129,7 @@ class Medium {
       mediumType.hashCode ^
       width.hashCode ^
       height.hashCode ^
+      orientation.hashCode ^
       mimeType.hashCode ^
       creationDate.hashCode ^
       modifiedDate.hashCode;
@@ -131,6 +140,7 @@ class Medium {
         'mediumType: $mediumType, '
         'width: $width, '
         'height: $height, '
+        'orientation: $orientation, '
         'mimeType: $mimeType, '
         'creationDate: $creationDate, '
         'modifiedDate: $modifiedDate}';


### PR DESCRIPTION
On Android photos can have set the parameter 'orientation' to 90 or 270 degree. In this case the width and height of the photo is swapped compared to the provided parameters.
This change introduces the orientation parameter for Android, so the user can decide what to do. For iOS the parameter does not exist and is set to 0 in this case.