### PR TITLE
Fix Issue #58 in media_page.dart line 22 type 'Null' is not a subtype of type 'int'

### DIFF
--- a/lib/src/models/media_page.dart
+++ b/lib/src/models/media_page.dart
@@ -19,7 +19,7 @@ class MediaPage {
 
   /// Creates a range of media from platform channel protocol.
   MediaPage.fromJson(this.album, dynamic json)
-      : start = json['start'],
+      : start = json['start'] ?? 0,
         items = json['items'].map<Medium>((x) => Medium.fromJson(x)).toList();
 
   /// Gets the next page of media in the album.
@@ -42,8 +42,7 @@ class MediaPage {
           listEquals(items, other.items);
 
   @override
-  int get hashCode =>
-      album.hashCode ^ start.hashCode ^ items.hashCode;
+  int get hashCode => album.hashCode ^ start.hashCode ^ items.hashCode;
 
   @override
   String toString() {


### PR DESCRIPTION
I am running album.listMedia(take: limit), and receive an exception <type 'Null' is not a subtype of type 'int'> specifically in media_page.dart line 22.

In line 22:
start: start = json['start'] //is returning null instead of an int

I fixed the bug just with
start = json['start'] ?? 0